### PR TITLE
Fix typo

### DIFF
--- a/src/content/1.7/themes/reference/javascript-events/_index.md
+++ b/src/content/1.7/themes/reference/javascript-events/_index.md
@@ -54,7 +54,7 @@ Event Name            | Description
  `updateDeliveryForm` | During checkout, if the delivery address is modified, this event will be trigged.
  `changedCheckoutStep` | Each checkout step **submission** will fire this event.
  `updateProductList`  | On every product list page (category, search results, pricedrop and so on), the list is updated via ajax calls if you change filters or sorting options. Each time the DOM is reloaded with new product list, this event is triggered.
- `clickQuickView`     | If your theme handles it, this event will be trigged when use click on the quickview link.
+ `clickQuickView`     | If your theme handles it, this event will be trigged when you click on the quickview link.
  `updateProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. After the update, this event is fired.
  `updatedProduct`      | On the product page, selecting a new combination will reload the DOM via ajax calls. After the update, this event is fired.
  `handleError`        | This event is fired after a fail of POST request. Have the `eventType` as first parameter.


### PR DESCRIPTION
Wrong word used in clickQuickView event description

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Rewording
| Fixed ticket? | No

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
